### PR TITLE
Update 02_01_entityruler.ipynb

### DIFF
--- a/02_01_entityruler.ipynb
+++ b/02_01_entityruler.ipynb
@@ -116,7 +116,7 @@
    "source": [
     "*Depending on the version of model you are using, some results may vary.*\n",
     "\n",
-    "The output from the code above demonstrates spaCy's small model's to identify Treblinka, which is a small village in Poland. As the sample text indicates, it was also an extermination camp during WWII. In the first sentence, the spaCy model tagged Treblinka as an LOC (location) and in the second it was missed entirely. Both are either imprecise or wrong. I would have accepted ORG for the second sentence, as spaCy's model does not know how to classify an extermination camp, but what these results demonstrate is the model's failure to generalize on data. The reason? There are a few, but I suspect the model never encountered the word Treblinka.\n",
+    "The output from the code above demonstrates spaCy's small model's to identify Treblinka, which is a small village in Poland. As the sample text indicates, it was also an extermination camp during WWII. In the first sentence, the spaCy models have tagged Treblinka as an LOC (location) or as a GPE (geo-political entity) and in the second it was missed entirely. Both are either imprecise or wrong. I would have accepted ORG for the second sentence, as spaCy's model does not know how to classify an extermination camp, but what these results demonstrate is the model's failure to generalize on data. The reason? There are a few, but I suspect the model never encountered the word Treblinka.\n",
     "\n",
     "This is a common problem in NLP for specific domains. Often times the domains in which we wish to deploy models, off-the-shelf models will fail because they have not been trained on domain-specific texts. We can resolve this, however, either via spaCy's EntityRuler or via training a new model. As we will see over the next few notebooks, we can use spaCy's EntityRuler to easily achieve both.\n",
     "\n",
@@ -319,7 +319,7 @@
     "\n",
     "If you are working within a United States domain, you can pass RegEx formulas to the pattern matcher to grab all of these instances.\n",
     "\n",
-    "The spaCy EntityRuler also allows the user to introduce a variety of complex rules and variances (via, among other things, RegEx) by passing the rules to the pattern. There are many arguments that one can pass to the patterns. For a complete list, see: https://spacy.io/usage/rule-based-matching . To expiremnet with how these work, I recommend using the spaCy Matcher demo: https://explosion.ai/demos/matcher .\n",
+    "The spaCy EntityRuler also allows the user to introduce a variety of complex rules and variances (via, among other things, RegEx) by passing the rules to the pattern. There are many arguments that one can pass to the patterns. For a complete list, see: https://spacy.io/usage/rule-based-matching . To experiment with how these work, I recommend using the spaCy Matcher demo: https://explosion.ai/demos/matcher .\n",
     "\n",
     "In the example below we work with one example from the spaCy documentation in which we extract a phone number from a text. This same task can be done via RegEx as well."
    ]


### PR DESCRIPTION
Treblinca  as LOC: current versions of Spacy report as GPE.  Suggested an edit to text, but it may not be correct.
corrected typo "expiremnet"  --> experiment