### PR TITLE
Update 02_01_entityruler.ipynb

### DIFF
--- a/02_01_entityruler.ipynb
+++ b/02_01_entityruler.ipynb
@@ -252,9 +252,9 @@
    "source": [
     "This can be a bit difficult to read at first, but what it shows us is the order in which our pipes are set up and a few other key pieces of information about each pipe. If we locate \"ner\", we notice that \"entity_ruler\" sits behind it.\n",
     "\n",
-    "In order for our EntityRuler to have primacy, we have to assign it to after the \"ner\" pipe, as the example below shows in this line:\n",
+    "In order for our EntityRuler to have primacy, we have to assign it to before the \"ner\" pipe, as the example below shows in this line:\n",
     "\n",
-    "ruler = nlp.add_pipe(\"entity_ruler\", **after=\"ner\"**)"
+    "ruler = nlp.add_pipe(\"entity_ruler\", **after=\"lemmatizer\"**)"
    ]
   },
   {


### PR DESCRIPTION
The line `ruler = nlp.add_pipe('entity_ruler')` adds the EntityRuler after `ner`. But based on the description and the context it appears we want it before. So in this case after `lemmatizer` ?