### PR TITLE
Update 01_02_linguistic_annotations.ipynb

### DIFF
--- a/01_02_linguistic_annotations.ipynb
+++ b/01_02_linguistic_annotations.ipynb
@@ -511,7 +511,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The token object contains a lot of different attributes that are VITAL do performing NLP in spaCy. We will be working with a few of them, such as:\n",
+    "The token object contains a lot of different attributes that are VITAL to performing NLP in spaCy. We will be working with a few of them, such as:\n",
     "\n",
     "* .text\n",
     "* .head\n",


### PR DESCRIPTION
modified ''do'' to  ''to'', for sentence clarity.